### PR TITLE
Encode output as UTF-8

### DIFF
--- a/grep-travis-logs.py
+++ b/grep-travis-logs.py
@@ -73,7 +73,6 @@ if __name__ == "__main__":
                 if re.search(args.pattern, line):
                     print(line)
         else:
-            print(log.body)
-
+            print(log.body.encode("utf-8"))
 
 # End of file


### PR DESCRIPTION
Fix: `UnicodeEncodeError: 'ascii' codec can't encode character u'\u2589' in position 74842: ordinal not in range(128)`